### PR TITLE
emit "open" event after receive PONG

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -99,10 +99,9 @@ class Client extends EventEmitter
     else
       @ws = new WebSocket @socketUrl
       @ws.on 'open', =>
-        @emit 'open'
         @connected = true
         @_connAttempts = 0
-        @_lastPong = Date.now()
+        @_lastPong = null
 
         # start pings
         @_pongTimeout = setInterval =>
@@ -465,6 +464,7 @@ class Client extends EventEmitter
         if message.reply_to
           if message.type == 'pong'
             @logger.debug 'pong'
+            @emit 'open' if not @_lastPong
             @_lastPong = Date.now()
             delete @_pending[message.reply_to]
           else if message.ok


### PR DESCRIPTION
I have a hubot that notify after it has been deployed.
## bug (?)

In following hubot script, first `robot.send` will not be sent.
```coffee
# Description:
#   deply notifer

module.exports = (robot) ->

  robot.send {room: "news"}, "Hubot deployed!"  ## this message will not send

  setTimeout ->
    robot.send {room: "news"}, "wait 5(sec), Hubot deployed!"  ## this is ok
  , 5000
```

## current implementation
node-slack-client emits `open` event after websocket was connected.
hubot-slack adapter receives `open` event, then emit `connected` event.
hubot receives `connected` event from adapter, then load `scripts/*.coffee`.

## fixed
emit `open` event after send PING and receive first PONG