### PR TITLE
Emit open event after hello, not before

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -99,8 +99,6 @@ class Client extends EventEmitter
     else
       @ws = new WebSocket @socketUrl
       @ws.on 'open', =>
-        @emit 'open'
-        @connected = true
         @_connAttempts = 0
         @_lastPong = Date.now()
 
@@ -321,6 +319,7 @@ class Client extends EventEmitter
       when "hello"
         # connected really really
         @connected = true
+        @emit 'open'
 
       when "presence_change"
         # find user by id and change their presence


### PR DESCRIPTION
This pull request takes a different approach to fixing the bug identified in #10. Previously messages sent immediately after the client has emitted the "open" event wouldn't appear in channel.

Waiting until after we've received a "hello" before emitting `open` fixes the bug. This is better than waiting for the next ping/pong timeout as it means you can respond immediately to the connection being established, instead of waiting a few seconds.
