### PR TITLE
Optionally specify a callback to client.openDM to get DM channel id

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -175,12 +175,15 @@ class Client extends EventEmitter
   _onJoinChannel: (data) =>
     @logger.debug data
 
-  openDM: (user_id) ->
+  openDM: (user_id, callback) ->
     params = {
       "user": user_id
     }
 
-    @_apiCall 'im.open', params, @_onOpenDM
+    if typeof callback is 'undefined'
+      callback = @_onOpenDM
+
+    @_apiCall 'im.open', params, callback
 
   _onOpenDM: (data) =>
     @logger.debug data


### PR DESCRIPTION
im.open returns a DM channel id like `D024BFF1M` but the caller of client.openDM has no way to get this information in order to pass to getDMByID and send messages via the channel. This allows you to specify an optional callback to get the channel ID returned by the API.