### PR TITLE
Test for valid (non-null) socket @ws in Client.reconnect() before @ws.cl...

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -154,7 +154,10 @@ class Client extends EventEmitter
       @_pongTimeout = null
 
     @authenticated = false
-    @ws.close()
+    
+    # Test for a null value on ws to prevent system failure (e.g. if Bot is disabled)
+    if @ws
+      @ws.close()
 
     @_connAttempts++
     # TODO: Check max reconnecting attempts and/or set a ceiling on this timeout


### PR DESCRIPTION
Test for valid (non-null) socket @ws in Client.reconnect() before @ws.close() to avoid system failure if the bot is disabled

![image](https://cloud.githubusercontent.com/assets/2982953/6461189/c5e5ba0e-c19d-11e4-9daa-05ff26cf375e.png)
