### PR TITLE
Pass down the websocket error.

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -120,9 +120,9 @@ class Client extends EventEmitter
         # flags.masked will be set if the data was masked
         @onMessage JSON.parse(data)
 
-      @ws.on 'error', =>
+      @ws.on 'error', (error)=>
         # TODO: Reconnect?
-        @emit 'error'
+        @emit 'error', error
 
       @ws.on 'close', =>
         @emit 'close'


### PR DESCRIPTION
Make sure the `error` listener can get this error. 

This will fix slackhq/hubot-slack#182