### PR TITLE
Fix Message Callbacks

### DIFF
--- a/src/message.coffee
+++ b/src/message.coffee
@@ -68,7 +68,7 @@ class Message
       @_client.logger.debug params
       @_client._apiCall "chat.update", params, @_onUpdateMessage
 
-  _onUpdateMessage: (data) ->
+  _onUpdateMessage: (data) =>
     @_client.logger.debug data
 
   deleteMessage: =>
@@ -81,7 +81,7 @@ class Message
       @_client.logger.debug params
       @_client._apiCall "chat.delete", params, @_onDeleteMessage
 
-  _onDeleteMessage: (data) ->
+  _onDeleteMessage: (data) =>
     @_client.logger.debug data
 
   _onMessageSent: (data) ->


### PR DESCRIPTION
Posting a message to a channel and then calling `updateMessage` or `deleteMessage` on that instance would throw an exception:
```
/Users/charlie/slack-poker-bot/node_modules/slack-client/src/message.js:106
    return this._client.logger.debug(data);
                       ^
TypeError: Cannot read property 'logger' of undefined
    at Message._onUpdateMessage (/Users/charlie/slack-poker-bot/node_modules/slack-client/src/message.js:106:24)
    at IncomingMessage.<anonymous> (/Users/charlie/slack-poker-bot/node_modules/slack-client/src/client.js:668:22)
    at IncomingMessage.emit (events.js:117:20)
    at _stream_readable.js:943:16
    at process._tickCallback (node.js:419:13)
```