### PR TITLE
Add "sendRaw" method to the Channel class

### DIFF
--- a/src/channel.coffee
+++ b/src/channel.coffee
@@ -86,6 +86,10 @@ class Channel
     m = new Message @_client, {text: text}
     @sendMessage m
 
+  sendRaw: (text) ->
+    m = new Message @_client, {text: text, parse: "none"}
+    @sendMessage m
+
   postMessage: (data) ->
     params = data
     params.channel = @id


### PR DESCRIPTION
This method works the same as "send", but it disables Slack message formatting. This allows users to send "raw" messages.

API reference where `parse` attribute is documented:

* https://api.slack.com/methods/chat.postMessage
* https://api.slack.com/docs/formatting (see "Parsing modes" section)