### PR TITLE
bump ws 0.4.31 -> 0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,7 @@
     "slack"
   ],
   "author": "Slack Technologies, Inc.",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://github.com/slackhq/node-slack-client/raw/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git://github.com/slackhq/node-slack-client.git"

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "coffee-script": "~1.9.3",
-    "ws": "0.8.0",
+    "ws": "0.8.1",
     "log": "1.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "coffee-script": "~1.9.3",
-    "ws": "0.4.31",
+    "ws": "0.7.2",
     "log": "1.4.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "coffee-script": "~1.9.3",
-    "ws": "0.7.2",
+    "ws": "0.8.0",
     "log": "1.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Bumps the ws npm to a more recent version.  Noticing quite a few reconnects / connection issues when connected for extended periods of time, so updating `ws` was low hanging fruit.

Verified that the API calls and events in use by slack-client are unchanged: https://github.com/websockets/ws/blob/master/doc/ws.md

There is a change in default protocol, though:
```
Protocol support
Hixie draft 76 (Old and deprecated, but still in use by Safari and Opera. Added to ws version 0.4.2, but server only. Can be disabled by setting the disableHixie option to true.)
HyBi drafts 07-12 (Use the option protocolVersion: 8)
HyBi drafts 13-17 (Current default, alternatively option protocolVersion: 13)
```
In my testing I haven't seen any issues, but would be good to hear from the Slack folks if we should specify protocolVersion: 8.

This is definitely a critical component for the library, so I'm not in a rush to get it merged until we get more eyes on it ;)

