### PR TITLE
ws: Review pong behavior (remove no-op)

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -130,7 +130,7 @@ class Client extends EventEmitter
         @socketUrl = null
 
       @ws.on 'ping', (data, flags) =>
-        @ws.pong
+        @ws.pong data, null, true
 
       return true
 

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -129,9 +129,6 @@ class Client extends EventEmitter
         @connected = false
         @socketUrl = null
 
-      @ws.on 'ping', (data, flags) =>
-        @ws.pong data, null, true
-
       return true
 
   disconnect: ->


### PR DESCRIPTION
Updated:

I noticed the @ws.pong is a no-op in the current slack-client version and thought we might need to call pong after a ping (manually).  After looking at ws, that doesn't seem to be the case in the both latest version and old 0.4.31 versions of `ws`:

onping is called after a ping:
https://github.com/websockets/ws/blob/master/lib/Receiver.js#L645
within onping, pong is called automatically at the ws level:
https://github.com/websockets/ws/blob/master/lib/WebSocket.js#L810 

Given the issues reported around disconnects / timeouts, I wanted to surface this for discussion.  I think this code should be removed since it is a no-op.
