### PR TITLE
Handle team_migration_started message + tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,9 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-release": "~0.6.0",
     "grunt-shell": "~0.5.0",
+    "mocha": "~1.13.0",
     "should": "~2.0.2",
-    "mocha": "~1.13.0"
+    "sinon": "^1.15.4"
   },
   "engines": {
     "node": ">= 0.10.x",

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -493,10 +493,7 @@ class Client extends EventEmitter
           @emit 'star_removed', message
 
       when 'team_migration_started'
-        autoReconnect = @autoReconnect
-        @disconnect()
-        @autoReconnect = autoReconnect
-        @login()
+        @reconnect()
         @emit 'team_migration_started', message
 
       else

--- a/src/client.coffee
+++ b/src/client.coffee
@@ -492,6 +492,13 @@ class Client extends EventEmitter
       when 'star_removed'
           @emit 'star_removed', message
 
+      when 'team_migration_started'
+        autoReconnect = @autoReconnect
+        @disconnect()
+        @autoReconnect = autoReconnect
+        @login()
+        @emit 'team_migration_started', message
+
       else
         if message.reply_to
           if message.type == 'pong'

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -2,7 +2,7 @@
 # Setup the tests
 ###################################################################
 should = require 'should'
-
+sinon = require 'sinon'
 Client = require '../src/client'
 
 # Generate a new instance for each test.
@@ -32,3 +32,30 @@ describe 'Client', ->
     it 'should strip hashes from the channel name', ->
       chan = client.getChannelByName '#bchan'
       chan.name.should.equal 'bchan'
+
+  describe '#onMessage', ->
+
+    describe 'type: team_migration_started', ->
+      beforeEach ->
+        client.connected = true
+        client.ws = {
+          close: ->
+        }
+        sinon.stub(client, 'login')
+        sinon.spy(client, 'disconnect')
+        client.onMessage {
+          "type": "team_migration_started"
+        }
+      
+      afterEach ->
+        client.connected = false
+        client.login.restore()
+        client.disconnect.restore()
+
+      it 'should call disconnect', ->
+        client.disconnect.called.should.equal true
+      it 'should call login', ->
+        client.login.called.should.equal true
+      it 'should preserve the autoReconnect setting', ->
+        client.autoReconnect.should.equal true
+

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -37,25 +37,13 @@ describe 'Client', ->
 
     describe 'type: team_migration_started', ->
       beforeEach ->
-        client.connected = true
-        client.ws = {
-          close: ->
-        }
-        sinon.stub(client, 'login')
-        sinon.spy(client, 'disconnect')
+        sinon.stub(client, 'reconnect')
         client.onMessage {
           "type": "team_migration_started"
         }
       
       afterEach ->
-        client.connected = false
-        client.login.restore()
-        client.disconnect.restore()
+        client.reconnect.restore()
 
-      it 'should call disconnect', ->
-        client.disconnect.called.should.equal true
-      it 'should call login', ->
-        client.login.called.should.equal true
-      it 'should preserve the autoReconnect setting', ->
-        client.autoReconnect.should.equal true
-
+      it 'should call reconnect', ->
+        client.reconnect.called.should.equal true


### PR DESCRIPTION
Attempt to address #51 

As the issue suggests, it's hard to reproduce.  This fix calls reconnect (close websocket and login again) and assumes the `migration_in_progress ` error referenced in https://api.slack.com/events/team_migration_started will come through rtm.start response within _onLogin's `!data.ok` error handler.  In that case, it will use the normal reconnect with backoff and respect the `autoReconnect` option.
