### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
+  - "0.12"
   - "0.11"
   - "0.10"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ node_js:
   - "0.12"
   - "0.11"
   - "0.10"
+before_install: npm install -g grunt-cli

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "http://github.com/slackhq/node-slack-client/issues"
   },
   "dependencies": {
-    "coffee-script": "^1.9.3",
+    "coffee-script": "~1.9.3",
     "ws": "0.4.31",
     "log": "1.4.0"
   },

--- a/package.json
+++ b/package.json
@@ -25,18 +25,19 @@
     "url": "http://github.com/slackhq/node-slack-client/issues"
   },
   "dependencies": {
-    "coffee-script": "~1.9.0",
+    "coffee-script": "^1.9.3",
     "ws": "0.4.31",
     "log": "1.4.0"
   },
   "devDependencies": {
+    "coffee-script": "^1.9.3",
     "grunt": "^0.4.5",
     "grunt-contrib-coffee": "^0.12.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-release": "~0.6.0",
     "grunt-shell": "~0.5.0",
-    "should": "~2.0.2",
-    "mocha": "~1.13.0"
+    "mocha": "~1.13.0",
+    "should": "~2.0.2"
   },
   "engines": {
     "node": ">= 0.10.x",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "log": "1.4.0"
   },
   "devDependencies": {
-    "coffee-script": "^1.9.3",
     "grunt": "^0.4.5",
     "grunt-contrib-coffee": "^0.12.0",
     "grunt-contrib-watch": "~0.5.3",


### PR DESCRIPTION
Fixes the travis CI build.  It was missing grunt-cli.

Passing build example: https://travis-ci.org/vanm/node-slack-client/builds/69354620