### PR TITLE
Add support for reaction events.

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -333,6 +333,16 @@ class Client extends EventEmitter
    onStarRemoved: (data) ->
      @emit 'star_removed', data
 
+   #
+   # Reactions handler callbacks and dispatches
+   #
+
+   onReactionAdded: (data) ->
+     @emit 'reaction_added', data
+
+   onReactionRemoved: (data) ->
+     @emit 'reaction_removed', data
+
   #
   # Message handler callback and dispatch
   #
@@ -492,6 +502,12 @@ class Client extends EventEmitter
       when 'star_removed'
           @emit 'star_removed', message
 
+      when 'reaction_added'
+          @emit 'reaction_added', message
+      
+      when 'reaction_removed'
+          @emit 'reaction_removed', message
+
       else
         if message.reply_to
           if message.type == 'pong'
@@ -513,7 +529,7 @@ class Client extends EventEmitter
             @emit 'error', if message.error? then message.error else message
             # TODO: resend?
         else
-          if message.type not in ["file_created", "file_shared", "file_unshared", "file_comment", "file_public", "file_comment_edited", "file_comment_deleted", "file_change", "file_deleted", "star_added", "star_removed"]
+          if message.type not in ["file_created", "file_shared", "file_unshared", "file_comment", "file_public", "file_comment_edited", "file_comment_deleted", "file_change", "file_deleted", "star_added", "star_removed", "reaction_added", "reaction_removed"]
             @logger.debug 'Unknown message type: '+message.type
             @logger.debug message
 


### PR DESCRIPTION
The object from this looks like this (unique IDs redacted):

Reaction added to a file:

    {
      type: 'reaction_added',
      user: '[REDACTED]',
      item: {
        type: 'file',
        file: '[REDACTED]'
      },
      reaction: 'grin',
      event_ts: '[REDACTED]' 
    }

Reaction removed from a message:

    {
      type: 'reaction_removed',
      user: '[REDACTED]',
      item: {
        type: 'message',
        channel: '[REDACTED]',
        ts: '[REDACTED]'
      },
      reaction: '+1',
      event_ts: '[REDACTED]'
    }

Note the `ts` property in the `type` object.

It's up to the app to look at the item property, check the type and act accordingly. Script used to test this:

    var S = require('slack-client');
    
    var slackOptions = {
      token: "YourTokenHere",
      autoReconnect: true,
      autoMark: true
    }
    
    var Cl = new S(slackOptions.token, slackOptions.autoReconnect, slackOptions.autoMark);
    
    Cl.login();
    Cl.on('open', function() {
    
    });
    
    Cl.on('reaction_added', function(reaction) {
      console.log(reaction);
    });
    Cl.on('reaction_removed', function(reaction) {
      console.log(reaction);
    });
