### PR TITLE
Added optional callback to channel.postMessage

### DIFF
--- a/src/channel.coffee
+++ b/src/channel.coffee
@@ -86,7 +86,7 @@ class Channel
     m = new Message @_client, {text: text}
     @sendMessage m
 
-  postMessage: (data) ->
+  postMessage: (data, callback) ->
     params = data
     params.channel = @id
     if data.attachments
@@ -94,7 +94,9 @@ class Channel
 
     @_client.logger.debug data
     @_client.logger.debug params
-    @_client._apiCall "chat.postMessage", params, @_onPostMessage
+    @_client._apiCall "chat.postMessage", params, =>
+      @_onPostMessage arguments...
+      callback? arguments...
 
   _onPostMessage: (data) =>
     @_client.logger.debug data


### PR DESCRIPTION
`channel.postMessage` is missing optional callback because it ends up hitting _apiCall. I just realized this after having race condition of multiple `postMessage` call.