### PR TITLE
Add count and callback to fetchHistory

### DIFF
--- a/src/channel.coffee
+++ b/src/channel.coffee
@@ -103,19 +103,22 @@ class Channel
     message.channel = @id
     @_client._send(message)
 
-  fetchHistory: (latest, oldest) ->
+  fetchHistory: (latest, oldest, count, callback) ->
     params = {
       "channel": @id
     }
 
     if latest? then params.latest = latest
     if oldest? then params.oldest = oldest
+    if count? then params.count = count
 
     method = 'channels.history'
     if @getType() == 'Group' then method = 'groups.history'
     if @getType() == 'DM' then method = 'im.history'
 
-    @_client._apiCall method, params, @_onFetchHistory
+    @_client._apiCall method, params, =>
+      @_onFetchHistory
+      callback? arguments...
 
   _onFetchHistory: (data) =>
     @_client.logger.debug data

--- a/test/channel.coffee
+++ b/test/channel.coffee
@@ -1,0 +1,60 @@
+###################################################################
+# Setup the tests
+###################################################################
+should = require 'should'
+
+Group = require '../src/group'
+
+# Rather than call out to the service, mock the API.
+class MockClient
+  constructor: (@verifyParams, @verifyMethod) ->
+    @logger = { debug: -> }
+
+  _apiCall: (method, params, callback) ->
+    @verifyParams params if @verifyParams
+    @verifyMethod method if @verifyMethod
+    callback status: 'ok'
+
+# Generate a new instance for each test.
+channel = null
+
+beforeEach ->
+  channel = new Group
+
+###################################################################
+# Start the tests
+###################################################################
+
+describe 'Channel', ->
+
+  describe '#fetchHistory', ->
+    it 'should pass oldest to _apiCall', ->
+      oldest = 123;
+      channel._client = new MockClient (params) ->
+        params.oldest.should.equal oldest
+      channel.fetchHistory null, oldest
+
+    it 'should pass latest to _apiCall', ->
+      latest = 456;
+      channel._client = new MockClient (params) ->
+        params.latest.should.equal latest
+      channel.fetchHistory latest
+
+    it 'should use correct method', ->
+      channel._client = new MockClient null, (method) ->
+        method.should.equal 'Group'
+      channel.fetchHistory
+
+    it 'should pass count to _apiCall', ->
+      channel._client = new MockClient (params) ->
+        params.count.should.equal 3
+      channel.fetchHistory null, null, 3
+
+    it 'should call callback', (done) ->
+      channel._client = new MockClient
+      latest = 123
+      oldest = 456
+      count = 3
+      channel.fetchHistory latest, oldest, count, (result) ->
+        result.should.not.be.null
+        done()


### PR DESCRIPTION
Adding the extra `count` parameter to fetch a maximum number of results, and adding a callback with similar behaviour to that of the `client`. Also added reasonably rudimentary tests for existing and new behaviour.