### PR TITLE
add check to avoir client crash when archiving

### DIFF
--- a/src/channel.coffee
+++ b/src/channel.coffee
@@ -133,7 +133,8 @@ class Channel
     @_client._apiCall method, params, @_onMark
 
   _onMark: (data) =>
-    @_client.logger.debug data
+    if @is_archived then return null
+    else @_client.logger.debug data
     # TODO: Update @unread_count based on ts
 
   leave: ->


### PR DESCRIPTION
When archiving a channel in which the bot is present, channel._onMark refers to a null object and crash. This bugfix adds a check to prevent it