### PR TITLE
Add support for https proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 *.js
+.idea

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "coffee-script": "~1.9.3",
     "ws": "0.8.1",
-    "log": "1.4.0"
+    "log": "1.4.0",
+    "https-proxy-agent": "1.0.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
Related to issue #33 this patch enables proxy support if a proxy URL is specified in the constructor to the Client class.