### PR TITLE
Pass through reaction_added messages

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -500,6 +500,9 @@ class Client extends EventEmitter
         @reconnect()
         @emit 'team_migration_started', message
 
+      when 'reaction_added'
+        @emit 'reaction_added', new Message(@, message)
+
       else
         if message.reply_to
           if message.type == 'pong'

--- a/test/client.coffee
+++ b/test/client.coffee
@@ -4,6 +4,7 @@
 should = require 'should'
 sinon = require 'sinon'
 Client = require '../src/client'
+Message = require '../src/message'
 
 # Generate a new instance for each test.
 client = null
@@ -47,3 +48,23 @@ describe 'Client', ->
 
       it 'should call reconnect', ->
         client.reconnect.called.should.equal true
+
+    describe 'type: reaction_added', ->
+      message = {
+        "type": "reaction_added"
+      }
+
+      beforeEach ->
+        sinon.stub(client, 'emit')
+        client.onMessage message
+      
+      afterEach ->
+        client.emit.restore()
+
+      it 'should emit a reaction_added Message', ->
+        client.emit.calledTwice.should.equal true
+        client.emit.args[0].should.eql ['raw_message', message]
+
+        args = client.emit.args[1]
+        args[0].should.eql 'reaction_added'
+        args[1].type.should.eql message.type


### PR DESCRIPTION
Just sends `reaction_added` messages straight through without any special treatment. Used to implement behavior needed by 18F/hubot-slack-github-issues.

I understand that 2.0 is on the way soon, and #59 is also still open, so no hard feelings if this gets closed without merging.

cc: @afeld @ccostino