### PR TITLE
Update ws to 1.0.1 due to security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "coffee-script": "~1.9.3",
-    "ws": "0.8.1",
+    "ws": "1.0.1",
     "log": "1.4.0",
     "https-proxy-agent": "1.0.0"
   },


### PR DESCRIPTION
Quick dependency version change due to a recent security advisory in `ws` https://nodesecurity.io/advisories/67