### PR TITLE
2.0.0: Do not override self user

### DIFF
--- a/lib/data-store/data-store.js
+++ b/lib/data-store/data-store.js
@@ -380,7 +380,7 @@ SlackDataStore.prototype.cacheRtmStart = function cacheRtmStart(data) {
     this.setBot(bot);
   }, this);
 
-  this.setUser(data.self);
+  this.getUserById(data.self.id).update(data.self);
   this.setTeam(data.team);
 };
 


### PR DESCRIPTION
Self is added to this.users during the forEach users loop with (with profile, isBot ...).

Then it's override by this.setUser(data.self) and so we loose profile, isBot...

The PR changed this behaviour and append self data (prefs...) to the existing user.