### PR TITLE
2.0.0: fix: cannot set autoreconnect to false

### DIFF
--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -77,7 +77,7 @@ function RTMClient(token, opts) {
   this.MAX_PONG_INTERVAL = clientOpts.maxPongInterval || 10000;
   this.WS_PING_INTERVAL = clientOpts.wsPingInterval || 5000;
 
-  this.autoReconnect = clientOpts.autoReconnect ? clientOpts.autoReconnect : true;
+  this.autoReconnect = clientOpts.autoReconnect !== false;
 }
 
 inherits(RTMClient, BaseAPIClient);


### PR DESCRIPTION
in the old code if clientOpts.autoReconnect is set to false, then the code set the variable to true (else case)