### PR TITLE
Enables the Slack V3 API to linkify link content

### DIFF
--- a/src/client.coffee
+++ b/src/client.coffee
@@ -547,7 +547,7 @@ class Client extends EventEmitter
     options =
       hostname: @host,
       method: 'POST',
-      path: '/api/' + method,
+      path: '/api/' + method + '?link_names=1',
       headers:
         'Content-Type': 'application/x-www-form-urlencoded',
         'Content-Length': post_data.length


### PR DESCRIPTION
This will enable the Slack v3 API to linkify any @username and #channel links in messages sent by hubot. 

Usage: "@#{username}"