### PR TITLE
Fixed dm.list method

### DIFF
--- a/lib/clients/client.js
+++ b/lib/clients/client.js
@@ -172,7 +172,7 @@ BaseAPIClient.prototype._callTransport = function _callTransport(task, queueCb) 
  * Makes a call to the Slack API.
  *
  * @param {String} endpoint The API endpoint to send to.
- * @param {Object=} optData The data send to the Slack API.
+ * @param {Object} optData The data send to the Slack API.
  * @param {function} optCb The callback to run on completion.
  */
 BaseAPIClient.prototype.makeAPICall = function makeAPICall(endpoint, optData, optCb) {

--- a/lib/clients/web/facets/dm.js
+++ b/lib/clients/web/facets/dm.js
@@ -59,7 +59,7 @@ DmFacet.prototype.history = function history(channel, opts, optCb) {
  * @param {function} optCb Optional callback, if not using promises.
  */
 DmFacet.prototype.list = function list(optCb) {
-  return this.makeAPICall('im.list', optCb);
+  return this.makeAPICall('im.list', {}, optCb);
 };
 
 /**


### PR DESCRIPTION
_Moved PR._
`BaseAPIClient.prototype.makeAPICall` `optData` param actually not optional. When you call it with two parameters, e.g. via `dm.list`, optional callback becomes second parameter, that causes error in `getData` and so on.