### PR TITLE
2.0.0: don't erase members when you rename a channel

### DIFF
--- a/lib/models/channel-group.js
+++ b/lib/models/channel-group.js
@@ -15,7 +15,7 @@ inherits(ChannelGroup, BaseChannel);
 
 
 ChannelGroup.prototype._setProperties = function setProperties(opts) {
-  this.members = opts.members || [];
+  this.members = this.members || [];
 
   ChannelGroup.super_.prototype._setProperties.call(this, opts);
 };


### PR DESCRIPTION
We only init members with an empty array if members is not existing.

BTW, I don't understand why you init members in _setProperties. It should have a `members = []` in the ctor of ChannelGroup.