### PR TITLE
2.0.0: removed toString()

### DIFF
--- a/lib/models/model.js
+++ b/lib/models/model.js
@@ -144,9 +144,4 @@ Model.prototype.toJSON = function toJSON() {
 };
 
 
-Model.prototype.toString = function toString() {
-
-};
-
-
 module.exports = Model;


### PR DESCRIPTION
JSON.stringify call toString() on the object if the function exists so when we try to json a model, it displays an empty string.

So I removed toString() to make JSON.stringify working