### PR TITLE
2.0.0: handleNewOrUpdatedUser don't update

### DIFF
--- a/lib/data-store/message-handlers/helpers.js
+++ b/lib/data-store/message-handlers/helpers.js
@@ -15,8 +15,13 @@ var noopMessage = function noopMessage(dataStore, message) {
  * {@link https://api.slack.com/events/user_change|user_change}
  */
 var handleNewOrUpdatedUser = function handleNewOrUpdatedUser(dataStore, message) {
-  var user = new models.User(message.user);
-  dataStore.setUser(user);
+  var user = dataStore.getUserById(message.user.id);
+  if(user) {
+    user.update(message.user);
+  } else {
+    user = new models.User(message.user);
+    dataStore.setUser(user);
+  }
 };
 
 

--- a/lib/data-store/message-handlers/helpers.js
+++ b/lib/data-store/message-handlers/helpers.js
@@ -16,12 +16,12 @@ var noopMessage = function noopMessage(dataStore, message) {
  */
 var handleNewOrUpdatedUser = function handleNewOrUpdatedUser(dataStore, message) {
   var user = dataStore.getUserById(message.user.id);
-  if(user) {
+  if (user) {
     user.update(message.user);
   } else {
     user = new models.User(message.user);
-    dataStore.setUser(user);
   }
+  dataStore.setUser(user);
 };
 
 


### PR DESCRIPTION
If `handleNewOrUpdatedUser` is called with an existing user we must update the user and not create a new one.
Without this patch if a user change his name dataStore loses the "presence" information (presence is not provide by user_change event).