### PR TITLE
fix path of require for memory-data-store in legacy-rtm

### DIFF
--- a/lib/clients/default/legacy-rtm.js
+++ b/lib/clients/default/legacy-rtm.js
@@ -4,7 +4,7 @@
 
 var inherits = require('inherits');
 
-var MemoryDataStore = require('../data-store/memory-data-store');
+var MemoryDataStore = require('../../data-store/memory-data-store');
 var RtmClient = require('../rtm/client');
 
 


### PR DESCRIPTION
With `slack-client` version `2.0.0-beta.4`.

```javascript
SlackClient = require('slack-client')
```

Is giving the following error:

```
module.js:338
    throw err;
          ^
Error: Cannot find module '../data-store/memory-data-store'
    at Function.Module._resolveFilename (module.js:336:15)
    at Function.Module._load (module.js:278:25)
    at Module.require (module.js:365:17)
    at require (module.js:384:17)
    at Object.<anonymous> (node_modules/slack-client/lib/clients/default/legacy-rtm.js:7:23)
    at Module._compile (module.js:460:26)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Module.require (module.js:365:17)
```