### PR TITLE
log RTM messages sent as well as received when logLevel is debug

### DIFF
--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -484,6 +484,7 @@ RTMClient.prototype.send = function send(message, optCb) {
   if (this.connected) {
     wsMsg.id = this.nextMessageId();
     jsonMessage = JSON.stringify(wsMsg);
+    this.logger.log('debug', jsonMessage);
 
     this._pendingMessages[wsMsg.id] = wsMsg;
     this.ws.send(jsonMessage, undefined, function handleWsMsgResponse(wsRespErr) {


### PR DESCRIPTION
Log sent as well as received messages on the RTM client if logLevel is "debug".

Before:
```
debug: {"type":"pong","reply_to":1}
debug: {"type":"pong","reply_to":2}
```

After:
```
debug: {"type":"ping","id":1}
debug: {"type":"pong","reply_to":1}
debug: {"type":"ping","id":2}
debug: {"type":"pong","reply_to":2}
```
