### PR TITLE
Replaced Travis-CI badge with an SVG version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Travis-CI Build Status
 
-[![Build Status](https://travis-ci.org/slackhq/node-slack-client.png?branch=master)](https://travis-ci.org/slackhq/node-slack-client)
+[![Build Status](https://travis-ci.org/slackhq/node-slack-client.svg?branch=master)](https://travis-ci.org/slackhq/node-slack-client)
 
 ## Description
 


### PR DESCRIPTION
Version 2.0 should come with a shinier badge.

![svg](https://cloud.githubusercontent.com/assets/542335/12800292/f8a00a0e-caa1-11e5-8a09-2f63668296e9.gif)
