### PR TITLE
fix TypeError when creating RTMClient with no opts

### DIFF
--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -59,7 +59,7 @@ function RTMClient(token, opts) {
   /**
    * @type {Function}
    */
-  this._socketFn = opts.socketFn || wsSocketFn;
+  this._socketFn = clientOpts.socketFn || wsSocketFn;
 
   /**
    * The active websocket.


### PR DESCRIPTION
```javascript
RtmClient = require('slack-client'). RtmClient
new RtmClient('<my-api-token>')
```

gives the following error:

```
TypeError·Cannot read property 'socketFn' of undefined
in slack-client/lib/clients/rtm/client.js:62
```

Note that this only happens if you don't pass `opts`. This code will work fine:

```javascript
new RtmClient('<my-api-token>', {})
```