### PR TITLE
pass data.error on CLIENT_EVENTS.FAILED_AUTHENTICATION to allow detecting account_inactive response

### DIFF
--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -218,8 +218,9 @@ RTMClient.prototype._onStart = function _onStart(err, data) {
   this._reconnecting = false;
 
   if (err || !data.url) {
-    this.logger.log('verbose', 'failed to connect to the RTM API: ' + err);
-    this.emit(CLIENT_EVENTS.FAILED_AUTHENTICATION, err);
+    var error = err || data.error;
+    this.logger.log('verbose', 'failed to connect to the RTM API: ' + error);
+    this.emit(CLIENT_EVENTS.FAILED_AUTHENTICATION, error);
     this.authenticated = false;
     if (this.autoReconnect) {
       this.reconnect();


### PR DESCRIPTION
If a bad token is passed to the `RtmClient` Slack will respond with something like the following:

```json
{
  "ok": false,
  "error": "account_inactive"
}
```

Right now the Slack error is not passed back to the `failed_auth` listener. With this change `failed_auth` will be called with`err` of `"account_inactive"`, `"invalid_auth"`, etc if Slack responds with those errors.