### PR TITLE
sync is_member on a channel_left event

### DIFF
--- a/lib/data-store/message-handlers/base-channel.js
+++ b/lib/data-store/message-handlers/base-channel.js
@@ -70,10 +70,10 @@ var handleRename = function handleRename(dataStore, message) {
 var handleLeave = function handleLeave(activeUserId, activeTeamId, dataStore, message) {
   var index;
 
-  var baseChanel = dataStore.getChannelGroupOrDMById(message.channel);
-  if (baseChanel) {
-    index = baseChanel.members.indexOf(activeUserId);
-    baseChanel.members.splice(index, 1);
+  var baseChannel = dataStore.getChannelGroupOrDMById(message.channel);
+  if (baseChannel) {
+    index = baseChannel.members.indexOf(activeUserId);
+    baseChannel.members.splice(index, 1);
   }
 };
 

--- a/lib/data-store/message-handlers/channels.js
+++ b/lib/data-store/message-handlers/channels.js
@@ -35,6 +35,14 @@ var handleChannelJoined = function handleChannelJoined(dataStore, message) {
   dataStore.upsertChannel(message.channel);
 };
 
+/** {@link https://api.slack.com/events/channel_left|channel_left} */
+var handleChannelLeft = function handleChannelLeft(activeUserId, activeTeamId, dataStore, message) {
+  baseChannelHandlers.handleLeave(activeUserId, activeTeamId, dataStore, message);
+  channel = dataStore.getChannelById(message.channel);
+  if (channel) {
+    channel.is_member = false;
+  }
+};
 
 var handlers = [
   [RTM_EVENTS.CHANNEL_ARCHIVE, baseChannelHandlers.handleArchive],
@@ -42,7 +50,7 @@ var handlers = [
   [RTM_EVENTS.CHANNEL_DELETED, handleChannelDeleted],
   [RTM_EVENTS.CHANNEL_HISTORY_CHANGED, helpers.noopMessage],
   [RTM_EVENTS.CHANNEL_JOINED, handleChannelJoined],
-  [RTM_EVENTS.CHANNEL_LEFT, baseChannelHandlers.handleLeave],
+  [RTM_EVENTS.CHANNEL_LEFT, handleChannelLeft],
   [RTM_EVENTS.CHANNEL_MARKED, baseChannelHandlers.handleChannelGroupOrDMMarked],
   [RTM_EVENTS.CHANNEL_RENAME, baseChannelHandlers.handleRename],
   [RTM_EVENTS.CHANNEL_UNARCHIVE, baseChannelHandlers.handleUnarchive],

--- a/lib/data-store/message-handlers/channels.js
+++ b/lib/data-store/message-handlers/channels.js
@@ -38,7 +38,7 @@ var handleChannelJoined = function handleChannelJoined(dataStore, message) {
 /** {@link https://api.slack.com/events/channel_left|channel_left} */
 var handleChannelLeft = function handleChannelLeft(activeUserId, activeTeamId, dataStore, message) {
   baseChannelHandlers.handleLeave(activeUserId, activeTeamId, dataStore, message);
-  channel = dataStore.getChannelById(message.channel);
+  var channel = dataStore.getChannelById(message.channel);
   if (channel) {
     channel.is_member = false;
   }

--- a/test/data-store/message-handlers/channel-group-dm.js
+++ b/test/data-store/message-handlers/channel-group-dm.js
@@ -110,7 +110,8 @@ describe('RTM API Message Handlers: Channel, Group & DM Events', function () {
     });
 
     it('removes a user from a channel when a `channel_left` message is received', function () {
-      testBaseChannelLeft('channel_left', TEST_CHANNEL_ID, 'U0F3LFX6K');
+      var channel = testBaseChannelLeft('channel_left', TEST_CHANNEL_ID, 'U0F3LFX6K');
+      expect(channel.is_member).to.be.false;
     });
 
     it('marks the channel as read when a `channel_marked` message is received', function () {


### PR DESCRIPTION
When a `channel_left` event is received for a channel set `is_member` to `false`.

This is significant for a bot client so they respond correctly if they are `/kick`ed from a channel.