### PR TITLE
Changed dm faucet name to im to match with Slack API method documentation

### DIFF
--- a/lib/clients/web/facets/dm.js
+++ b/lib/clients/web/facets/dm.js
@@ -11,7 +11,7 @@
  */
 
 function DmFacet(makeAPICall) {
-  this.name = 'dm';
+  this.name = 'im';
   this.makeAPICall = makeAPICall;
 }
 


### PR DESCRIPTION
Took me a while to find why `webClient.im.open` didn't work, after working with the Slack API docs.