### PR TITLE
Adds promises support to the client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### v2.0.7 ()
+
+ * Adds promises to the Slack clients. If no callback is passed to an API call, a promise will be created and returned instead.
+
 ### v2.0.6 (2016-03-01)
 
   * Fixes a crash introduce in `2.0.5` if you try and instantiate a `WebClient` without passing in any options

--- a/lib/clients/client.js
+++ b/lib/clients/client.js
@@ -3,6 +3,7 @@
  */
 
 var EventEmitter = require('eventemitter3');
+var Promise = require('bluebird');
 var async = require('async');
 var bind = require('lodash').bind;
 var inherits = require('inherits');
@@ -10,6 +11,7 @@ var partial = require('lodash').partial;
 var retry = require('retry');
 var urlJoin = require('url-join');
 
+var SlackAPIError = require('./errors').SlackAPIError;
 var getLogger = require('../helpers').getLogger;
 var helpers = require('./helpers');
 var requestsTransport = require('./transports/request').requestTransport;
@@ -136,9 +138,12 @@ BaseAPIClient.prototype._callTransport = function _callTransport(task, queueCb) 
  * @param {function=} optCb The callback to run on completion.
  */
 BaseAPIClient.prototype.makeAPICall = function makeAPICall(endpoint, optData, optCb) {
+  var promise;
+  var args;
+  var _this = this;
   var apiCallArgs = helpers.getAPICallArgs(this._token, optData, optCb);
 
-  var args = {
+  args = {
     url: urlJoin(this.slackAPIUrl, endpoint),
     data: apiCallArgs.data,
     headers: {
@@ -146,10 +151,31 @@ BaseAPIClient.prototype.makeAPICall = function makeAPICall(endpoint, optData, op
     }
   };
 
-  this.requestQueue.push({
-    args: args,
-    cb: apiCallArgs.cb
-  });
+  if (!apiCallArgs.cb) {
+    promise = new Promise(function makeAPICallPromiseResolver(resolve, reject) {
+      _this.requestQueue.push({
+        args: args,
+        cb: function makeAPICallPromiseResolverInner(err, res) {
+          if (err) {
+            reject(err);
+          } else {
+            if (!res.ok) {
+              reject(new SlackAPIError(res.error));
+            } else {
+              resolve(res);
+            }
+          }
+        }
+      });
+    });
+  } else {
+    this.requestQueue.push({
+      args: args,
+      cb: apiCallArgs.cb
+    });
+  }
+
+  return promise;
 };
 
 

--- a/lib/clients/errors.js
+++ b/lib/clients/errors.js
@@ -1,0 +1,14 @@
+
+var inherits = require('inherits');
+
+
+var SlackAPIError = function SlackAPIError(error) {
+  Error.captureStackTrace(this, this.constructor);
+  this.name = this.constructor.name;
+  this.message = error;
+};
+
+inherits(SlackAPIError, Error);
+
+
+module.exports.SlackAPIError = SlackAPIError;

--- a/lib/clients/helpers.js
+++ b/lib/clients/helpers.js
@@ -7,7 +7,6 @@ var isFunction = require('lodash').isFunction;
 var isUndefined = require('lodash').isUndefined;
 var isString = require('lodash').isString;
 var forEach = require('lodash').forEach;
-var noop = require('lodash').noop;
 
 
 /**
@@ -48,19 +47,16 @@ var getAPICallArgs = function getAPICallArgs(token, optData, optCb) {
   var cb;
 
   if (arguments.length === 1) {
-    // Pass in a no-op function here to avoid adding more conditionals in the _callTransport fn
-    cb = noop;
     data = getData({}, token);
   } else if (arguments.length === 2) {
     if (isFunction(arguments[1])) {
       cb = arguments[1];
       data = getData({}, token);
     } else {
-      cb = noop;
       data = getData(optData, token);
     }
   } else if (arguments.length === 3) {
-    cb = optCb || noop;
+    cb = optCb;
     data = getData(optData, token);
   }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "async": "^1.5.0",
+    "bluebird": "^3.3.3",
     "eventemitter3": "^1.1.1",
     "https-proxy-agent": "^1.0.0",
     "inherits": "^2.0.1",

--- a/test/clients/helpers.js
+++ b/test/clients/helpers.js
@@ -1,5 +1,4 @@
 var expect = require('chai').expect;
-var lodash = require('lodash');
 
 var helpers = require('../../lib/clients/helpers');
 
@@ -65,21 +64,19 @@ describe('Client Helpers', function () {
   });
 
   describe('#getAPICallArgs()', function () {
-    it('returns an empty object and noop fn when called with no data or cb', function () {
+    it('returns an object with the token when called with no data or cb', function () {
       var callArgs = helpers.getAPICallArgs('test');
       expect(callArgs.data).to.deep.equal({
         token: 'test'
       });
-      expect(callArgs.cb).to.deep.equal(lodash.noop);
     });
 
-    it('returns the supplied object and noop fn when called with an object and no cb', function () {
+    it('returns the supplied object when called with a data object and no cb', function () {
       var callArgs = helpers.getAPICallArgs('test', { test: 1 });
       expect(callArgs.data).to.deep.equal({
         test: 1,
         token: 'test'
       });
-      expect(callArgs.cb).to.deep.equal(lodash.noop);
     });
 
     it('returns the supplied cb and empty object when called with a cb and no object', function () {


### PR DESCRIPTION
If no callback is passed to an API call, a promise will be created and returned instead.