### PR TITLE
Logs a warning if an API response with a `warning` key is returned.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### v2.0.7 ()
 
  * Adds promises to the Slack clients. If no callback is passed to an API call, a promise will be created and returned instead.
+ * Logs a warning if an API response with a `warning` key is received
 
 ### v2.0.6 (2016-03-01)
 

--- a/lib/clients/transports/call-transport.js
+++ b/lib/clients/transports/call-transport.js
@@ -95,6 +95,10 @@ var handleHttpResponse = function handleHttpResponse(body, client, apiCb) {
     return false;
   }
 
+  if (!jsonParseErr && jsonResponse.warning) {
+    client.logger('warn', jsonResponse.warning);
+  }
+
   try {
     apiCb(jsonParseErr, jsonResponse);
   } catch (callbackErr) {


### PR DESCRIPTION
See https://api.slack.com/web for details

Fixes #157