### PR TITLE
Updates the RTM message send functionality.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### v2.2.0 ()
+
+  * Adds promise support to the RTM client `send` and `sendMessage` methods
+  * Fixes the way message response callbacks work, so that the success case is only called when the websocket receives a message with a `reply_to` matching the id of the dispatched message, instead of when the ws instance signals message send success
+
 ### v2.1.0 (2016-03-05)
 
  * Adds promises to the Slack clients. If no callback is passed to an API call, a promise will be created and returned instead.

--- a/lib/clients/errors.js
+++ b/lib/clients/errors.js
@@ -20,4 +20,4 @@ inherits(SlackRTMSendError, SlackAPIError);
 
 
 module.exports.SlackAPIError = SlackAPIError;
-module.exports.SlackRTMError = SlackRTMSendError;
+module.exports.SlackRTMSendError = SlackRTMSendError;

--- a/lib/clients/errors.js
+++ b/lib/clients/errors.js
@@ -1,6 +1,6 @@
+/* eslint vars-on-top: 0 */
 
 var inherits = require('inherits');
-
 
 var SlackAPIError = function SlackAPIError(error) {
   Error.captureStackTrace(this, this.constructor);
@@ -11,4 +11,13 @@ var SlackAPIError = function SlackAPIError(error) {
 inherits(SlackAPIError, Error);
 
 
+var SlackRTMSendError = function SlackRTMError(error, message) {
+  SlackAPIError.call(this, error);
+  this.message = message;
+};
+
+inherits(SlackRTMSendError, SlackAPIError);
+
+
 module.exports.SlackAPIError = SlackAPIError;
+module.exports.SlackRTMError = SlackRTMSendError;

--- a/lib/clients/errors.js
+++ b/lib/clients/errors.js
@@ -11,9 +11,9 @@ var SlackAPIError = function SlackAPIError(error) {
 inherits(SlackAPIError, Error);
 
 
-var SlackRTMSendError = function SlackRTMError(error, message) {
+var SlackRTMSendError = function SlackRTMError(error, rtmMessage) {
   SlackAPIError.call(this, error);
-  this.message = message;
+  this.rtmMessage = rtmMessage;
 };
 
 inherits(SlackRTMSendError, SlackAPIError);

--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -3,11 +3,15 @@
  * See [the RTM client events](../events/client) for details of the client event lifecycle.
  */
 
+var Promise = require('bluebird');
 var bind = require('lodash').bind;
 var cloneDeep = require('lodash').cloneDeep;
 var contains = require('lodash').contains;
+var hasKey = require('lodash').has;
 var inherits = require('inherits');
+var isFunction = require('lodash').isFunction;
 var isUndefined = require('lodash').isUndefined;
+var noop = require('lodash').noop;
 
 var RTM_API_EVENTS = require('../events/rtm').EVENTS;
 var RTM_CLIENT_INTERNAL_EVENT_TYPES = [
@@ -23,6 +27,7 @@ var UNRECOVERABLE_RTM_START_ERRS = [
 var CLIENT_EVENTS = require('../events/client').RTM;
 var BaseAPIClient = require('../client');
 var RtmFacet = require('../web/facets').RtmFacet;
+var SlackRTMSendError = require('../errors').SlackRTMSendError;
 var makeMessageEventWithSubtype = require('../events/utils').makeMessageEventWithSubtype;
 var wsSocketFn = require('../transports/ws');
 
@@ -65,6 +70,20 @@ function RTMClient(token, opts) {
    */
   this.ws = undefined;
 
+  /**
+   *
+   * @type {number}
+   * @private
+   */
+  this._messageId = 1;
+
+  /**
+   *
+   * @type {{}}
+   * @private
+   */
+  this._msgResponseHandlers = {};
+
   if (!isUndefined(clientOpts.dataStore)) {
     this.registerDataStore(clientOpts.dataStore);
   }
@@ -104,14 +123,6 @@ RTMClient.prototype.activeUserId = undefined;
  * @type {string}
  */
 RTMClient.prototype.activeTeamId = undefined;
-
-
-/**
- * Maps message id to message object for messages sent to but not replied to by the remote server.
- * @type {Object}
- * @private
- */
-RTMClient.prototype._pendingMessages = {};
 
 
 /**
@@ -198,9 +209,10 @@ RTMClient.prototype.login = function login(opts) {
 
 /**
  * Generates the next message id to use.
+ *
+ * NOTE: This id must be unique per RTM connection.
  */
 RTMClient.prototype.nextMessageId = function nextMessageId() {
-  this._messageId = this._messageId || 1;
   return this._messageId++;
 };
 
@@ -322,7 +334,7 @@ RTMClient.prototype._pingServer = function _pingServer() {
   var pongInterval;
 
   if (this.connected) {
-    this.send({ type: 'ping' });
+    this.send({ type: 'ping' }, noop);
 
     // If the last pong was more than MAX_PONG_INTERVAL, force a reconnect
     pongInterval = Date.now() - this._lastPong;
@@ -403,22 +415,20 @@ RTMClient.prototype._handleWsMessageViaEventHandler = function _handleWsMessageV
   messageType, message) {
   var replyTo;
 
+  if (!isUndefined(this.dataStore)) {
+    this.dataStore.handleRtmMessage(this.activeUserId, this.activeTeamId, messageType, message);
+  }
+
   if (messageType === RTM_API_EVENTS.MESSAGE) {
     replyTo = message.reply_to;
     if (replyTo) {
-      // TODO(leah): figure out how message pushes via the RTM API should work and how any errors
-      //             will be handled
-      if (this._pendingMessages[replyTo]) {
-        delete this._pendingMessages[replyTo];
+      if (hasKey(this._msgResponseHandlers, replyTo)) {
+        this._handleMsgResponse(replyTo, null, message);
       } else {
         // If the message was sent in reply to a message that's not on this client, skip the message
         return;
       }
     }
-  }
-
-  if (!isUndefined(this.dataStore)) {
-    this.dataStore.handleRtmMessage(this.activeUserId, this.activeTeamId, messageType, message);
   }
 
   this.emit(messageType, message);
@@ -473,7 +483,7 @@ RTMClient.prototype.handleWsPing = function handleWsPing() {
  */
 RTMClient.prototype._handlePong = function _handlePong(message) {
   this._lastPong = Date.now();
-  delete this._pendingMessages[message.reply_to];
+  this._handleMsgResponse(message.reply_to, null, message);
 };
 
 
@@ -491,7 +501,7 @@ RTMClient.prototype._handleHello = function _handleHello() {
  * @param {Function=} optCb
  */
 RTMClient.prototype.sendMessage = function sendMessage(text, channelId, optCb) {
-  this.send({
+  return this.send({
     text: text,
     channel: channelId,
     type: RTM_API_EVENTS.MESSAGE
@@ -505,33 +515,106 @@ RTMClient.prototype.sendMessage = function sendMessage(text, channelId, optCb) {
  * @param {Function=} optCb
  */
 RTMClient.prototype.send = function send(message, optCb) {
-  var wsMsg = cloneDeep(message);
-  var jsonMessage;
   var err;
-  var _this = this;
+  var ret;
 
   if (this.connected) {
-    wsMsg.id = this.nextMessageId();
-    jsonMessage = JSON.stringify(wsMsg);
-    this.logger('debug', jsonMessage);
+    ret = this._send(message, optCb);
+  } else {
+    err = new SlackRTMSendError('ws not connected, unable to send message', message);
+    this.logger('error', err);
 
-    this._pendingMessages[wsMsg.id] = wsMsg;
-    this.ws.send(jsonMessage, undefined, function handleWsMsgResponse(wsRespErr) {
+    if (optCb) {
+      setTimeout(function wsSendDisconnectedCb() {
+        optCb(err, null);
+      }, 1);
+    } else {
+      ret = new Promise(function wsSendDisconnectedPromise(fulfill, reject) {
+        reject(err);
+      });
+    }
+  }
+
+  return ret;
+};
+
+
+/**
+ *
+ * @param message
+ * @param optCb
+ * @returns {*}
+ * @private
+ */
+RTMClient.prototype._send = function _send(message, optCb) {
+  var _this = this;
+  var jsonMessage;
+  var ret;
+  var msgId = this.nextMessageId();
+
+  var wsMsg = cloneDeep(message);
+  wsMsg.id = msgId;
+
+  jsonMessage = JSON.stringify(wsMsg);
+  this.logger('debug', 'sending message via ws: ' + jsonMessage);
+
+  if (optCb) {
+    _this._registerMsgHandler(msgId, optCb);
+    this.ws.send(jsonMessage, undefined, function handleWsMsgResponseCb(wsRespErr) {
       if (!isUndefined(wsRespErr)) {
-        _this.logger('debug', 'Unable to send message: ' + wsRespErr);
-      }
-
-      if (!isUndefined(optCb)) {
-        optCb(wsRespErr);
+        _this._handleMsgResponse(msgId, wsRespErr);
       }
     });
   } else {
-    err = 'ws not connected, unable to send message';
-    this.logger('debug', err);
-    if (!isUndefined(optCb)) {
-      optCb(new Error(err));
+    ret = new Promise(function wsSendPromiseInner(fulfill, reject) {
+      _this._registerMsgHandler(msgId, { fulfill: fulfill, reject: reject });
+      _this.ws.send(jsonMessage, undefined, function handleWsMsgResponseCb(wsRespErr) {
+        if (!isUndefined(wsRespErr)) {
+          _this._handleMsgResponse(msgId, wsRespErr, null);
+        }
+      });
+    });
+  }
+
+  return ret;
+};
+
+
+/**
+ * Registers a handler, either a function or {fulfill: fn, reject: fn}, for a message id.
+ * @param {number} msgId The id of the message to handle.
+ * @param {*} handler
+ * @private
+ */
+RTMClient.prototype._registerMsgHandler = function _registerMsgHandler(msgId, handler) {
+  this._msgResponseHandlers[msgId] = handler;
+};
+
+
+/**
+ * Calls the handler registered for a given msgId and cleans it up on completion.
+ * @param {number} msgId The id of the message to handle.
+ * @param {Object} err
+ * @param {Object} res
+ * @private
+ */
+RTMClient.prototype._handleMsgResponse = function _handleMsgResponse(msgId, err, res) {
+  var responseHandler = this._msgResponseHandlers[msgId];
+  if (err) {
+    this.logger('debug', 'Error sending message: ' + err);
+  }
+
+  if (isFunction(responseHandler)) {
+    responseHandler(err, res);
+  } else {
+    if (err) {
+      responseHandler.reject(err);
+    } else {
+      responseHandler.fulfill(res);
     }
   }
+
+  delete this._msgResponseHandlers[msgId];
 };
 
 

--- a/lib/clients/rtm/client.js
+++ b/lib/clients/rtm/client.js
@@ -84,6 +84,14 @@ function RTMClient(token, opts) {
    */
   this._msgResponseHandlers = {};
 
+
+  /**
+   *
+   * @type {{}}
+   * @private
+   */
+  this._msgChannelLookup = {};
+
   if (!isUndefined(clientOpts.dataStore)) {
     this.registerDataStore(clientOpts.dataStore);
   }
@@ -413,27 +421,100 @@ RTMClient.prototype._handleWsMessageInternal = function _handleWsMessageInternal
  */
 RTMClient.prototype._handleWsMessageViaEventHandler = function _handleWsMessageViaEventHandler(
   messageType, message) {
-  var replyTo;
+  var replyTo = message.reply_to;
 
   if (!isUndefined(this.dataStore)) {
     this.dataStore.handleRtmMessage(this.activeUserId, this.activeTeamId, messageType, message);
   }
 
-  if (messageType === RTM_API_EVENTS.MESSAGE) {
-    replyTo = message.reply_to;
-    if (replyTo) {
-      if (hasKey(this._msgResponseHandlers, replyTo)) {
-        this._handleMsgResponse(replyTo, null, message);
-      } else {
-        // If the message was sent in reply to a message that's not on this client, skip the message
-        return;
-      }
+  // This means that the message is an ack of a message sent via the websocket from the client.
+  // The expected structure is something like:
+  // {
+  //   "ok": true,
+  //   "reply_to": 1,
+  //   "ts": "1355517523.000005",
+  //   "text": "Hello world"
+  // }
+  // ... in the case of success.
+  //
+  // See the Sending messages section of https://api.slack.com/rtm for details.
+  if (replyTo) {
+    this._handleMsgReply(replyTo, message, messageType);
+  } else {
+    // Non reply_to messages should *always* have a type
+    this.emit(messageType, message);
+    if (messageType === RTM_API_EVENTS.MESSAGE && !isUndefined(message.subtype)) {
+      this.emit(makeMessageEventWithSubtype(message.subtype), message);
     }
   }
+};
 
-  this.emit(messageType, message);
-  if (messageType === RTM_API_EVENTS.MESSAGE && !isUndefined(message.subtype)) {
-    this.emit(makeMessageEventWithSubtype(message.subtype), message);
+
+/**
+ *
+ * @param replyTo
+ * @param message
+ * @param messageType
+ * @private
+ */
+RTMClient.prototype._handleMsgReply = function _handleMsgReply(replyTo, message, messageType) {
+  var msg;
+  var channel;
+
+  if (!messageType) {
+    if (hasKey(this._msgResponseHandlers, replyTo)) {
+      if (!message.ok) {
+        this._handleMsgResponse(replyTo, new SlackRTMSendError(message.error.msg, message), null);
+      } else {
+        channel = this._msgChannelLookup[replyTo];
+
+        // Make a synthetic message, rather than passing back the raw ack response
+        msg = {
+          type: 'message',
+          channel: channel,
+          user: this.activeUserId,
+          text: message.text,
+          ts: message.ts
+        };
+
+        if (this.dataStore) {
+          // TODO(leah): Update the relevant channel history with this message
+          // this.dataStore.getChannelById(channel);
+        }
+
+        this._handleMsgResponse(replyTo, null, msg);
+      }
+    } else {
+      // This should be impossible. If the message is received with no message type, it's a response
+      // to a message sent by this client, so the absence of a handler for it should never happen.
+      this.logger.error('message received with unknown reply_to: ' + message);
+    }
+  } else {
+    // The server will send the most recent reply message to the client when it first connects,
+    // so will receive a message that looks like:
+    //
+    // {
+    //   "reply_to": 848,
+    //   "type": "message",
+    //   "channel": "C0CHZA86Q",
+    //   "user": "U0CJ5PC7L",
+    //   "text": "meh-mah",
+    //   "ts": "1457327357.000011"
+    // }
+    //
+    // This should generally only happen in the case of disconnections. If that happens, the last
+    // message should be handled gracefully.
+
+    // TODO(leah): The client should probably also enqueue messages locally so that they can resent
+    // in the event of disconnection
+
+    if (this._msgResponseHandlers[replyTo]) {
+      msg = cloneDeep(message);
+      delete msg.reply_to;
+      this._handleMsgResponse(replyTo, null, msg);
+    } else {
+      // TODO(leah): Figure out what to do here
+    }
   }
 };
 
@@ -510,6 +591,18 @@ RTMClient.prototype.sendMessage = function sendMessage(text, channelId, optCb) {
 
 
 /**
+ * Sends a typing indicator to indicate that the user with `activeUserId` is typing.
+ * @param {string} channelId The id of the channel|group|DM to send this message to.
+ */
+RTMClient.prototype.sendTyping = function sendTyping(channelId) {
+  this.send({
+    type: 'typing',
+    channel: channelId
+  }, noop);
+};
+
+
+/**
  * Sends a message over the websocket to the server.
  * @param {*} message The message to send back to the server.
  * @param {Function=} optCb
@@ -559,7 +652,7 @@ RTMClient.prototype._send = function _send(message, optCb) {
   this.logger('debug', 'sending message via ws: ' + jsonMessage);
 
   if (optCb) {
-    _this._registerMsgHandler(msgId, optCb);
+    _this._registerMsgHandler(msgId, wsMsg, optCb);
     this.ws.send(jsonMessage, undefined, function handleWsMsgResponseCb(wsRespErr) {
       if (!isUndefined(wsRespErr)) {
         _this._handleMsgResponse(msgId, wsRespErr);
@@ -567,7 +660,7 @@ RTMClient.prototype._send = function _send(message, optCb) {
     });
   } else {
     ret = new Promise(function wsSendPromiseInner(fulfill, reject) {
-      _this._registerMsgHandler(msgId, { fulfill: fulfill, reject: reject });
+      _this._registerMsgHandler(msgId, wsMsg, { fulfill: fulfill, reject: reject });
       _this.ws.send(jsonMessage, undefined, function handleWsMsgResponseCb(wsRespErr) {
         if (!isUndefined(wsRespErr)) {
           _this._handleMsgResponse(msgId, wsRespErr, null);
@@ -583,16 +676,31 @@ RTMClient.prototype._send = function _send(message, optCb) {
 /**
  * Registers a handler, either a function or {fulfill: fn, reject: fn}, for a message id.
  * @param {number} msgId The id of the message to handle.
+ * @param {object} wsMsg
  * @param {*} handler
  * @private
  */
-RTMClient.prototype._registerMsgHandler = function _registerMsgHandler(msgId, handler) {
+RTMClient.prototype._registerMsgHandler = function _registerMsgHandler(msgId, wsMsg, handler) {
+  //
+  // Track the channel a message was sent to.
+  //
+  // This is so that the client can create a synthetic message object when it receives the message
+  // ack from the RTM API server. This allows:
+  //   - passing back a full message object, rather than an ack message, to the client that sent the
+  //     message
+  //   - pushing a standard message into the relevant channel's history
+  //
+  if (wsMsg.type === 'message' && wsMsg.channel) {
+    this._msgChannelLookup[msgId] = wsMsg.channel;
+  }
+
   this._msgResponseHandlers[msgId] = handler;
 };
 
 
 /**
  * Calls the handler registered for a given msgId and cleans it up on completion.
+ *
  * @param {number} msgId The id of the message to handle.
  * @param {Object} err
  * @param {Object} res
@@ -614,6 +722,7 @@ RTMClient.prototype._handleMsgResponse = function _handleMsgResponse(msgId, err,
     }
   }
 
+  delete this._msgChannelLookup[msgId];
   delete this._msgResponseHandlers[msgId];
 };
 

--- a/test/clients/rtm/client.js
+++ b/test/clients/rtm/client.js
@@ -116,4 +116,85 @@ describe('RTM API Client', function () {
 
   });
 
+  describe('Message Sending', function () {
+
+    it('should call a cb with an err when the RTM client is not connected', function (done) {
+      var rtm = new RtmAPIClient('fake-token');
+      rtm.sendMessage('test', 'test', function (err, res) {
+        expect(err).to.not.equal(null);
+        expect(res).to.equal(null);
+        done();
+      });
+    });
+
+    it('should call a catch cb with an err when the RTM client is not connected', function (done) {
+      var rtm = new RtmAPIClient('fake-token');
+      rtm.sendMessage('test', 'test')
+        .catch(function (err) {
+          expect(err).to.not.equal(null);
+          done();
+        });
+    });
+
+    it('should call the `ws.send` method when the send or sendMessage function is called');
+
+  });
+
+  describe('Message Response Handling', function () {
+
+    describe('#_registerMsgHandler()', function () {
+
+      it('should write to _msgResponseHandlers when _registerMsgHandler is called', function () {
+        var rtm = new RtmAPIClient('fake-token');
+        var fakeHandler = { fulfill: null, reject: null };
+        rtm._registerMsgHandler(1, fakeHandler);
+        expect(rtm._msgResponseHandlers[1]).to.deep.equal(fakeHandler);
+      });
+
+    });
+
+    describe('#_handleMsgResponse()', function () {
+
+      var setupRTMClient = function (handler) {
+        var rtm = new RtmAPIClient('fake-token');
+        rtm._registerMsgHandler(1, handler);
+
+        return rtm;
+      };
+
+      it('calls a registered callback fn when a message response or err is received', function () {
+        var handler = sinon.spy();
+        var rtm = setupRTMClient(handler);
+        rtm._handleMsgResponse(1, null, 'test');
+
+        expect(handler.calledWith(null, 'test')).to.equal(true);
+      });
+
+      it('should call a registered fulfill fn when a message response is received', function () {
+        var handler = { fulfill: sinon.spy(), reject: null };
+        var rtm = setupRTMClient(handler);
+        rtm._handleMsgResponse(1, null, 'test');
+
+        expect(handler.fulfill.calledWith('test')).to.equal(true);
+      });
+
+      it('should call a registered reject fn when a message response is received', function () {
+        var handler = { fulfill: null, reject: sinon.spy() };
+        var rtm = setupRTMClient(handler);
+        rtm._handleMsgResponse(1, 'test', null);
+
+        expect(handler.reject.calledWith('test')).to.equal(true);
+      });
+
+      it('deletes the response handler when a message response or err is received', function () {
+        var rtm = setupRTMClient(function () {});
+        rtm._handleMsgResponse(1, null, 'test');
+
+        expect(rtm._msgResponseHandlers[1]).to.equal(undefined);
+      });
+
+    });
+
+  });
+
 });

--- a/test/clients/rtm/client.js
+++ b/test/clients/rtm/client.js
@@ -144,11 +144,14 @@ describe('RTM API Client', function () {
 
     describe('#_registerMsgHandler()', function () {
 
-      it('should write to _msgResponseHandlers when _registerMsgHandler is called', function () {
+      it('should write to _msgResponseHandlers and _msgChannelLookup', function () {
         var rtm = new RtmAPIClient('fake-token');
         var fakeHandler = { fulfill: null, reject: null };
-        rtm._registerMsgHandler(1, fakeHandler);
+        var wsMsg = { type: 'message', channel: 'fake', text: 'test', id: 1 };
+        rtm._registerMsgHandler(1, wsMsg, fakeHandler);
+
         expect(rtm._msgResponseHandlers[1]).to.deep.equal(fakeHandler);
+        expect(rtm._msgChannelLookup[1]).to.deep.equal('fake');
       });
 
     });
@@ -157,7 +160,8 @@ describe('RTM API Client', function () {
 
       var setupRTMClient = function (handler) {
         var rtm = new RtmAPIClient('fake-token');
-        rtm._registerMsgHandler(1, handler);
+        var wsMsg = { type: 'message', channel: 'fake', text: 'test', id: 1 };
+        rtm._registerMsgHandler(1, wsMsg, handler);
 
         return rtm;
       };
@@ -186,11 +190,12 @@ describe('RTM API Client', function () {
         expect(handler.reject.calledWith('test')).to.equal(true);
       });
 
-      it('deletes the response handler when a message response or err is received', function () {
+      it('deletes the response handler and channel lookup', function () {
         var rtm = setupRTMClient(function () {});
         rtm._handleMsgResponse(1, null, 'test');
 
         expect(rtm._msgResponseHandlers[1]).to.equal(undefined);
+        expect(rtm._msgChannelLookup[1]).to.equal(undefined);
       });
 
     });


### PR DESCRIPTION
This:
- adds promise support to the RTM send / sendMessage functions
- updates the way message responses are handled, so that the message success callback is triggered when the API returns a message object with a `reply_to` matching the id of the sent message

Fixes #163