### PR TITLE
Fixed opts data not being validated

### DIFF
--- a/lib/clients/helpers.js
+++ b/lib/clients/helpers.js
@@ -15,7 +15,8 @@ var forEach = require('lodash').forEach;
  * @returns {object}
  */
 var getData = function getData(data, token) {
-  var newData = assign({}, data ? data.opts || {} : {});
+  var newData = {};
+  assign(data, data ? data.opts || {} : {});
 
   forEach(data || {}, function getValidData(val, key) {
     if (!isUndefined(val) && val !== null && key !== 'opts') {


### PR DESCRIPTION
This fix forces data inside the ```opts``` key to be processed by ```getValidData()```.
In situations where you would add attachments they would not be processed meaning that the attachments array would not be stringified, causing the  API to respond with an ```invalid_array_arg``` error.