### PR TITLE
lodash.find doesn't seem to be used correctly in the default MemoryDataStore.getUserByEmail

### DIFF
--- a/lib/data-store/memory-data-store.js
+++ b/lib/data-store/memory-data-store.js
@@ -88,7 +88,7 @@ SlackMemoryDataStore.prototype.getUserByName = function getUserByName(name) {
 
 /** @inheritdoc */
 SlackMemoryDataStore.prototype.getUserByEmail = function getUserByEmail(email) {
-  return find(this.users, 'email', email);
+  return find(this.users, {profile: {email: email}});
 };
 
 

--- a/test/data-store/memory-data-store.js
+++ b/test/data-store/memory-data-store.js
@@ -57,6 +57,30 @@ describe('MemoryDataStore', function () {
     });
   });
 
+  describe('#getUserByEmail()', function () {
+    var dataStore = getMemoryDataStore();
+
+    it('should get a user by email', function () {
+      expect(dataStore.getUserByEmail('leah+slack-api-test-alice@slack-corp.com').id).to.equal('U0CJ5PC7L');
+    });
+
+    it('should return undefined if no users with email is not found', function () {
+      expect(dataStore.getUserByEmail('NOT-leah+slack-api-test-bob@slack-corp.com')).to.equal(undefined);
+    });
+  });
+
+  describe('#getUserByName()', function () {
+    var dataStore = getMemoryDataStore();
+
+    it('should get a user by name', function () {
+      expect(dataStore.getUserByName('alice').id).to.equal('U0CJ5PC7L');
+    });
+
+    it('should return undefined if no users with name is not found', function () {
+      expect(dataStore.getUserByEmail('NOTalice')).to.equal(undefined);
+    });
+  });
+
   describe('#clear()', function () {
     it('should re-set the objects when clear() is called', function () {
       var dataStore = getMemoryDataStore();


### PR DESCRIPTION
Take for example `MemoryDataStore.getUserByEmail`:
```
SlackMemoryDataStore.prototype.getUserByEmail = function getUserByEmail(email) {
  return find(this.users, 'email', email);
};
```

An example user object stored in `SlackMemoryDataStore.users` looks like:
```
let user = {
	_modelName: "User",
	_properties: Object,
	color: "d1707d",
	deleted: false,
	is_admin: false,
	is_bot: false,
	is_owner: false,
	is_primary_owner: false,
	is_restricted: false,
	is_ultra_restricted: false,
	name: "simonsays",
	presence: "active",
	profile: {
		email: "myemail@provider.com",
		first_name: "Simon",
		last_name: "Yousoufov",
		real_name: "Simon Yousoufov",
		real_name_normalized: "Simon Yousoufov",
		title: "Web Developer"
	},
	real_name: "Simon Yousoufov"
}
```

The `email` attribute is located at `user.profile.email` whereas `getUserByEmail` seems to be searching for just `user.email`.

The quick solution is to replace the MemoryDataStore used by RTMClient but the actual fix would be something like:

```
SlackMemoryDataStore.prototype.getUserByEmail = function getUserByEmail(email) {
  return find(this.users, {profile: {email: email}});
};
```