### PR TITLE
Fix linting errors and run ESLint on Travis

### DIFF
--- a/lib/data-store/memory-data-store.js
+++ b/lib/data-store/memory-data-store.js
@@ -88,7 +88,7 @@ SlackMemoryDataStore.prototype.getUserByName = function getUserByName(name) {
 
 /** @inheritdoc */
 SlackMemoryDataStore.prototype.getUserByEmail = function getUserByEmail(email) {
-  return find(this.users, {profile: {email: email}});
+  return find(this.users, { profile: { email: email } });
 };
 
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "./index",
   "scripts": {
     "lint": "eslint . --ignore-path .gitignore",
-    "test": "mocha --recursive --reporter spec test",
+    "mocha": "mocha --recursive --reporter spec test",
+    "test": "npm run lint && npm run mocha",
     "cover": "istanbul cover --report lcovonly _mocha -- --recursive",
     "coveralls": "npm run cover && istanbul-coveralls"
   },

--- a/test/data-store/memory-data-store.js
+++ b/test/data-store/memory-data-store.js
@@ -61,11 +61,13 @@ describe('MemoryDataStore', function () {
     var dataStore = getMemoryDataStore();
 
     it('should get a user by email', function () {
-      expect(dataStore.getUserByEmail('leah+slack-api-test-alice@slack-corp.com').id).to.equal('U0CJ5PC7L');
+      var user = dataStore.getUserByEmail('leah+slack-api-test-alice@slack-corp.com');
+      expect(user.id).to.equal('U0CJ5PC7L');
     });
 
     it('should return undefined if no users with email is not found', function () {
-      expect(dataStore.getUserByEmail('NOT-leah+slack-api-test-bob@slack-corp.com')).to.equal(undefined);
+      var user = dataStore.getUserByEmail('NOT-leah+slack-api-test-bob@slack-corp.com');
+      expect(user).to.equal(undefined);
     });
   });
 


### PR DESCRIPTION
Makes `npm test` run both ESLint and Mocha - could fix it by adding `npm run lint` to `travis.yml`'s script field too.